### PR TITLE
Update self-referencing badge URLs to /blob/main/ after branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 <br/>
 
 <p align="center">
-  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/master/docs/ICS/Industrial-Control-Systems.md"><img src="https://img.shields.io/badge/🏭_ICS-SCADA_&_OT-ff6b6b?style=for-the-badge"/></a>&nbsp;
-  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/master/docs/Automotive/automotive-security.md"><img src="https://img.shields.io/badge/🚗_AUTO-CAN_&_ECU-4ecdc4?style=for-the-badge"/></a>&nbsp;
-  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/master/docs/awesome-collection.md"><img src="https://img.shields.io/badge/📚_AWESOME-COLLECTION-a855f7?style=for-the-badge"/></a>&nbsp;
-  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/master/CONTRIBUTING.md"><img src="https://img.shields.io/badge/🤝_CONTRIBUTE-JOIN_US-f59e0b?style=for-the-badge"/></a>
+  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/main/docs/ICS/Industrial-Control-Systems.md"><img src="https://img.shields.io/badge/🏭_ICS-SCADA_&_OT-ff6b6b?style=for-the-badge"/></a>&nbsp;
+  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/main/docs/Automotive/automotive-security.md"><img src="https://img.shields.io/badge/🚗_AUTO-CAN_&_ECU-4ecdc4?style=for-the-badge"/></a>&nbsp;
+  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/main/docs/awesome-collection.md"><img src="https://img.shields.io/badge/📚_AWESOME-COLLECTION-a855f7?style=for-the-badge"/></a>&nbsp;
+  <a href="https://github.com/V33RU/awesome-connected-things-sec/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/🤝_CONTRIBUTE-JOIN_US-f59e0b?style=for-the-badge"/></a>
 </p>
 
 <br/>


### PR DESCRIPTION
## Summary
- Renames 4 self-referencing badge/anchor URLs in the README from `/blob/master/` to `/blob/main/` after the default branch was renamed.
- External-repo links (NSA ghidra, swisskyrepo, sgayou, wcventure) intentionally left on `master` since those upstream repos still use that name.

## Test plan
- [ ] Verify the 4 top-of-README badges (ICS, Auto, Awesome Collection, Contribute) resolve to live pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)