### PR TITLE
docs: add MQTT Topic ACL Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,7 @@
 - [Mosquitto - Open Source MQTT Broker](https://mosquitto.org/)
 - [HiveMQ](https://www.hivemq.com/)
 - [MQTT Explorer](http://mqtt-explorer.com/)
+- [MQTT Topic ACL Linter](https://github.com/visoar/mqtt-acl-linter) - Local-only static analysis for invalid, broad, duplicate, and overlapping MQTT topic-filter ACL rules; does not connect to a broker or replace a security audit.
 - [Nmap MQTT Library](https://nmap.org/nsedoc/lib/mqtt.html)
 - [Seven Best MQTT Client Tools](https://www.hivemq.com/blog/seven-best-mqtt-client-tools)
 


### PR DESCRIPTION
## Summary

Adds one entry to MQTT → Tools for the open-source MQTT Topic ACL Linter.

The tool performs local-only static analysis for invalid, broad, duplicate, and overlapping MQTT topic-filter ACL rules. The listing states that it does not connect to a broker and does not replace a security audit.

## Why

The MQTT Tools section currently includes brokers, clients, Nmap support, and client roundups, but no dedicated topic-filter ACL static checker. The linked repository includes source, fixtures, automated tests, a documented rule set, limitations, and an MIT license.

## Validation

- checked the current README and all open/closed PRs for a duplicate MQTT ACL Linter entry
- confirmed the source repository and raw LICENSE return HTTP 200
- ran `git diff --check`
- limited the change to one README entry

Disclosure: I am a maintainer of RunMQTT and the mqtt-acl-linter project.