### PR TITLE
Add router default-password compliance research (277 manufacturer-verified models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1527,6 +1527,7 @@
 - [Lenovo Watch X Privacy Issues](https://www.checkmarx.com/blog/lenovo-watch-watching-you/)
 - [Smart Scale Privacy Issues](https://www.checkmarx.com/blog/smart-scale-privacy-issues-iot/)
 - [Besder IP Camera Security Analysis](https://github.com/KostasEreksonas/Besder-6024PB-XMA501-ip-camera-security-investigation)
+- [Router Default-Password Rates by Brand (277 manufacturer-verified models)](https://ssid.ai/reports/router-default-credentials-2026)
 
 ### Blogs
 


### PR DESCRIPTION
Adds one line to **Research and Community → Technical Research**.

**What it is:** a 2026 measurement of how many consumer/SMB router, mesh, gateway and AP models still ship a *universal default password* — the pattern the UK PSTI Act (in force April 2024) prohibits and the EU Cyber Resilience Act targets.

- 277 models, **81 (29%)** still ship a universal default.
- Every credential type is cited to the **manufacturer's own documentation** (support page, manual PDF or spec sheet) — not scraped from an existing password list.
- The counter-intuitive finding: mass-market consumer brands have largely moved off it (ASUS 1/20, TP-Link 3/28), while SMB/prosumer vendors have not (Peplink 9/9, DrayTek 6/6, Netgate 5/5).
- JSON export at `/data.json`, and an append-only version history so a vendor quietly changing a documented default is caught with a timestamp.

**Disclosure:** I maintain ssid.ai. Submitting it because the list's Technical Research section collects primary findings and I couldn't find base-rate data on this anywhere else — most "change your default password" advice cites no measurement. Happy to drop it if it's not a fit, or move it to a different section if you'd prefer.
